### PR TITLE
Fix callback_message missing `conn` argument and some PEP8

### DIFF
--- a/skeleton.py
+++ b/skeleton.py
@@ -40,7 +40,7 @@ class Skeleton(BotPlugin):
 		You should delete it if you're not using it to override any default behaviour"""
 		pass
 
-	def callback_message(self, conn, message):
+	def callback_message(self, message):
 		"""Triggered for every received message that isn't coming from the bot itself
 
 		You should delete it if you're not using it to override any default behaviour"""

--- a/skeleton.py
+++ b/skeleton.py
@@ -4,62 +4,62 @@ from errbot import BotPlugin, botcmd, webhook
 
 
 class Skeleton(BotPlugin):
-	"""An Err plugin skeleton"""
-	min_err_version = '1.6.0' # Optional, but recommended
-	max_err_version = '2.0.0' # Optional, but recommended
+    """An Err plugin skeleton"""
+    min_err_version = '1.6.0' # Optional, but recommended
+    max_err_version = '2.0.0' # Optional, but recommended
 
-	def activate(self):
-		"""Triggers on plugin activation
+    def activate(self):
+        """Triggers on plugin activation
 
-		You should delete it if you're not using it to override any default behaviour"""
-		super(Skeleton, self).activate()
+        You should delete it if you're not using it to override any default behaviour"""
+        super(Skeleton, self).activate()
 
-	def deactivate(self):
-		"""Triggers on plugin deactivation
+    def deactivate(self):
+        """Triggers on plugin deactivation
 
-		You should delete it if you're not using it to override any default behaviour"""
-		super(Skeleton, self).deactivate()
+        You should delete it if you're not using it to override any default behaviour"""
+        super(Skeleton, self).deactivate()
 
-	def get_configuration_template(self):
-		"""Defines the configuration structure this plugin supports
+    def get_configuration_template(self):
+        """Defines the configuration structure this plugin supports
 
-		You should delete it if your plugin doesn't use any configuration like this"""
-		return {'EXAMPLE_KEY_1': "Example value",
-		        'EXAMPLE_KEY_2': ["Example", "Value"]
-		       }
+        You should delete it if your plugin doesn't use any configuration like this"""
+        return {'EXAMPLE_KEY_1': "Example value",
+                'EXAMPLE_KEY_2': ["Example", "Value"]
+               }
 
-	def check_configuration(self, configuration):
-		"""Triggers when the configuration is checked, shortly before activation
+    def check_configuration(self, configuration):
+        """Triggers when the configuration is checked, shortly before activation
 
-		You should delete it if you're not using it to override any default behaviour"""
-		super(Skeleton, self).check_configuration()
+        You should delete it if you're not using it to override any default behaviour"""
+        super(Skeleton, self).check_configuration()
 
-	def callback_connect(self):
-		"""Triggers when bot is connected
+    def callback_connect(self):
+        """Triggers when bot is connected
 
-		You should delete it if you're not using it to override any default behaviour"""
-		pass
+        You should delete it if you're not using it to override any default behaviour"""
+        pass
 
-	def callback_message(self, message):
-		"""Triggered for every received message that isn't coming from the bot itself
+    def callback_message(self, message):
+        """Triggered for every received message that isn't coming from the bot itself
 
-		You should delete it if you're not using it to override any default behaviour"""
-		pass
+        You should delete it if you're not using it to override any default behaviour"""
+        pass
 
-	def callback_botmessage(self, message):
-		"""Triggered for every message that comes from the bot itself
+    def callback_botmessage(self, message):
+        """Triggered for every message that comes from the bot itself
 
-		You should delete it if you're not using it to override any default behaviour"""
-		pass
+        You should delete it if you're not using it to override any default behaviour"""
+        pass
 
-	@webhook
-	def example_webhook(self, incoming_request):
-		"""A webhook which simply returns 'Example'"""
-		return "Example"
+    @webhook
+    def example_webhook(self, incoming_request):
+        """A webhook which simply returns 'Example'"""
+        return "Example"
 
-	# Passing split_args_with=None will cause arguments to be split on any kind
-	# of whitespace, just like Python's split() does
-	@botcmd(split_args_with=None)
-	def example(self, mess, args):
-		"""A command which simply returns 'Example'"""
-		return "Example"
+    # Passing split_args_with=None will cause arguments to be split on any kind
+    # of whitespace, just like Python's split() does
+    @botcmd(split_args_with=None)
+    def example(self, mess, args):
+        """A command which simply returns 'Example'"""
+        return "Example"


### PR DESCRIPTION
```
01:59:11 ERROR    errbot.errBot             Crash in a callback_message
handler
Traceback (most recent call last):
File "/Users/lekov/Workspace/elsys/errbot/errbot/errBot.py", line
523, in callback_message
plugin.callback_message(mess)
TypeError: callback_message() missing 1 required positional argument:
'message'
```

https://github.com/errbotio/errbot/blob/master/errbot/botplugin.py#L258
